### PR TITLE
update to include .sandbox. prefix to .lightning domain to accommodate Hyperforce server URL patterns

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -11,6 +11,7 @@
 			.replace(/\.[^\.]+\.my\.salesforce\.com/, '')
 			.replace('.my.salesforce.com', '')
 			.replace('.lightning.force.com', '')
+			.replace('.sandbox.lightning.force.com', '')
 			.replace(/--c\.[^\.]+\.visual\.force\.com/, '');
 	};
 

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -19,7 +19,8 @@
 			"matches": [
 				"*://*.salesforce.com/*",
 				"*://*.visual.force.com/*",
-				"*://*.lightning.force.com/*"
+				"*://*.lightning.force.com/*",
+				"*://*.sandbox.lightning.force.com/*"
 			],
 			"js": [ "content.js" ],
 			"all_frames": false,


### PR DESCRIPTION
updated two files (following pattern from PR#6) by adding .sandbox. prefix to .lightning domain to accommodate Hyperforce server URL patterns.

not sure if this will work, as not sure how to test it (I am not familiar with Chrome extension development...)

let me know if there are other tweaks required, or there is a way for me to test this before submitting a PR...
